### PR TITLE
FIX: Hour wrong in edge-cases in fuzzy mode

### DIFF
--- a/src/text-da.c
+++ b/src/text-da.c
@@ -68,9 +68,16 @@ void get_hour_string_da(int hour, int minute, char *hourBuffer, size_t length)
 {
     memset(hourBuffer, 0, length);
 
+#ifdef FUZZY
+    // calculate hour based on fuzzy minutes
+    // (otherwise we get e.g. "5 minutter i halv elleve"
+    //  when its 11:24 and should say "... i halv tolv")
+    minute = (((minute + 2) / 5) * 5) % 60;
+#endif
+
     if (minute >= 25)
         hour++;
-        
+
     strcat(hourBuffer, NUMBERS[hour % 12]);
 }
 


### PR DESCRIPTION
Added the fuzzy minute-calculation to get_hour_string_da, to avoid errors in edge case:
right now 11:24 leads to 5 minutter i halv elleve  when it should say " ... i halv tolv"